### PR TITLE
Review API usage to improve UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can also find additional examples from [zcaffeine’s tests](src/test/scala/
 // get or compute
 cache.get("key")
 // get all or compute all
-cache.getAll(Set("key1","key2"), keys => ZIO.succeed(keys.map(key => (key, key + key)).toMap))
+cache.getAll("key1","key2"))(keys => ZIO.succeed(keys.map(key => (key, key + key)).toMap))
 // get only if cached
 cache.getIfPresent("key3")
 // insert or replace
@@ -97,7 +97,7 @@ cache.invalidate("key")
 // invalidate all
 cache.invalidateAll
 // invalidate all specified keys
-cache.invalidateAll(Set("key1","key2"))
+cache.invalidateAll("key1","key2")
 
 
 /*****************************************************/
@@ -112,7 +112,7 @@ cache.getAll(Set("key1","key2"))
 // refresh using the functions set while building the cache and get
 cache.refresh("key1")
 // refresh all using the functions set while building the cache and get all
-cache.refreshAll(Set("key1","key2")) 
+cache.refreshAll("key1","key2")
 ```
 ## License
 

--- a/src/test/scala/com/stuart/zcaffeine/CacheSpec.scala
+++ b/src/test/scala/com/stuart/zcaffeine/CacheSpec.scala
@@ -13,8 +13,8 @@ object CacheSpec extends ZIOSpecDefault {
           zcaffeine <- ZCaffeine[TestEnvironment, String, Int]()
           cache     <- zcaffeine.build()
           missing   <- cache.getIfPresent("key")
-          created   <- cache.get("key", key => ZIO.succeed(key.length))
-          unchanged <- cache.get("key", key => ZIO.succeed(key.length + 1))
+          created   <- cache.get("key")(key => ZIO.succeed(key.length))
+          unchanged <- cache.get("key")(key => ZIO.succeed(key.length + 1))
           present   <- cache.getIfPresent("key")
         } yield assert(missing)(isNone) &&
           assert(created)(equalTo(3)) &&
@@ -27,11 +27,9 @@ object CacheSpec extends ZIOSpecDefault {
           cache     <- zcaffeine.build()
           missing1  <- cache.getIfPresent("key")
           missing2  <- cache.getIfPresent("key2")
-          created   <- cache.getAll(Set("key", "key2"), keys => ZIO.succeed(keys.map(key => key -> key.length).toMap))
-          unchanged <- cache.getAll(
-                         Set("key", "key2"),
-                         keys => ZIO.succeed(keys.map(key => key -> (key.length + 1)).toMap)
-                       )
+          created   <- cache.getAll("key", "key2")(keys => ZIO.succeed(keys.map(key => key -> key.length).toMap))
+          unchanged <-
+            cache.getAll(Set("key", "key2"))(keys => ZIO.succeed(keys.map(key => key -> (key.length + 1)).toMap))
         } yield assert(missing1)(isNone) &&
           assert(missing2)(isNone) &&
           assert(created)(equalTo(Map("key" -> 3, "key2" -> 4))) &&
@@ -54,13 +52,13 @@ object CacheSpec extends ZIOSpecDefault {
         for {
           zcaffeine   <- ZCaffeine[TestEnvironment, String, Int]()
           cache       <- zcaffeine.build()
-          _           <- cache.getAll(Set("key", "key2"), keys => ZIO.succeed(keys.map(key => key -> key.length).toMap))
+          _           <- cache.getAll("key", "key2")(keys => ZIO.succeed(keys.map(key => key -> key.length).toMap))
           _           <- cache.invalidate("key")
           keyMissing  <- cache.getIfPresent("key")
           key2Present <- cache.getIfPresent("key2")
           _           <- cache.invalidateAll
           key2Missing <- cache.getIfPresent("key2")
-          _           <- cache.getAll(Set("key", "key2"), keys => ZIO.succeed(keys.map(key => key -> key.length).toMap))
+          _           <- cache.getAll(Set("key", "key2"))(keys => ZIO.succeed(keys.map(key => key -> key.length).toMap))
           _           <- cache.invalidateAll(Set("key", "key2"))
           keyMissingAgain  <- cache.getIfPresent("key")
           key2MissingAgain <- cache.getIfPresent("key2")


### PR DESCRIPTION
* Add variants of `*All` methods with varargs, to avoid wrapping
  everything in Sets
* Move the mapping function to a separate parameter list, to improve
  cases where you’d want to have a more complex function as a block
  expression

Before:

```scala
cache.getAll(Set("key", "key2"))(keys => {
  val foo = ???
  ZIO
    .attempt(foo)
    .orElse(ZIO.attempt(???))
    .orElseSucceed(???)
})
```

After:

```scala
cache.getAll("key", "key2") { keys =>
  val foo = ???
  ZIO
    .attempt(foo)
    .orElse(ZIO.attempt(???))
    .orElseSucceed(???)
}
```