### PR TITLE
add asMap to get the cache contents as an immutable Map

### DIFF
--- a/src/main/scala/com/stuart/zcaffeine/Cache.scala
+++ b/src/main/scala/com/stuart/zcaffeine/Cache.scala
@@ -125,6 +125,14 @@ sealed class Cache[R, Key, Value] private[zcaffeine] (runtime: Runtime[R], under
     ZIO.attemptBlocking(underlying.synchronous().stats())
 
   /**
+   * Returns an immutable view of the cache contents.
+   * @return
+   * the cache contents, as a Map
+   */
+  def asMap: Task[Map[Key,Value]] =
+    ZIO.attemptBlocking(underlying.synchronous().asMap().asScala.toMap)
+
+  /**
    * Immediately run any pending maintenance operations on this cache, such as evicting expired entries.
    * @return
    */


### PR DESCRIPTION
Same as #25, but for the ZIO 2 branch.